### PR TITLE
Added 'text-shadow' CSS attribute to valid list of text attributes.

### DIFF
--- a/toyplot/require.py
+++ b/toyplot/require.py
@@ -61,6 +61,7 @@ style.text = set([
     "stroke-opacity",
     "stroke-width",
     "text-anchor",
+    "text-shadow",
     "-toyplot-anchor-shift",
     ])
 


### PR DESCRIPTION
We use text-shadow in some of our graphs and tables. Its particularly useful to make text pop when the background is a little busy, eg a photo. Believe it or not but we use some plots with transparent background in front of live video.