### PR TITLE
include -toyplot-anchor-shift in calculation of line.right extents fo…

### DIFF
--- a/toyplot/text.py
+++ b/toyplot/text.py
@@ -326,7 +326,7 @@ def layout(text, style, fonts):
 
                 # Line left/right/bottom/top are relative offsets from the layout anchor in canvas coordinates.
                 line.left = offset_x
-                line.right = offset_x + line.width
+                line.right = offset_x + line.width + line.style["-toyplot-anchor-shift"]
                 line.top += offset_y
                 line.baseline = offset_y
                 line.bottom += offset_y


### PR DESCRIPTION
I was having problems with text being cut-off on the right side because the Marker extents `layout.right` attribute did not appear to take into account the `-toyplot-anchor-shift` value. This was a problem for Toytree because I would routinely plot text with style `{'text-anchor': 'start', '-toyplot-anchor-shift': '20px'}`. 

This problem is also apparent in the example for `-toyplot-anchor-shift` from the Toyplot documentation:

```Python
canvas = toyplot.Canvas(width=500, height=300)
axes = canvas.cartesian(show=False, ymin=-2.5, ymax=1.5)
axes.vlines(0, color="lightgray")
axes.text(0, 1, "Shifted +0px", style={"-toyplot-anchor-shift":"0", "text-anchor":"start", "font-size":"24px"})
axes.scatterplot(0, 1, color="black", size=3)
m0 = axes.text(0, 0, "Shifted +20px", style={"-toyplot-anchor-shift":"20px", "text-anchor":"start", "font-size":"24px"})
axes.scatterplot(0, 0, color="black", size=3)
m1 = axes.text(0, -1, "Shifted +40px", style={"-toyplot-anchor-shift":"40px", "text-anchor":"start", "font-size":"24px"})
axes.scatterplot(0, -1, color="black", size=3);
axes.text(0, -2, "Shifted -20px", style={"-toyplot-anchor-shift":"-20px", "text-anchor":"start", "font-size":"24px"})
axes.scatterplot(0, -2, color="black", size=3);
```

The marker extents do not take into account the anchor shift. You can see the right value is unchanged for `m0` and `m1`:
```
>>> m0.extents('x')[1], m1.extents('x')[1]
```
```
((array([ 0.]), array([ 147.432]), array([-14.4]), array([ 14.4])),
 (array([ 0.]), array([ 147.432]), array([-14.4]), array([ 14.4])))
```

After making the edit that is in the pull request the extents seem to appropriately valued:
```
>>> m0.extents('x')[1], m1.extents('x')[1]
```
```
((array([ 0.]), array([ 167.432]), array([-14.4]), array([ 14.4])),
 (array([ 0.]), array([ 187.432]), array([-14.4]), array([ 14.4])))
```
