### PR TITLE
Makes toyplot work with python 3.10 due to an API change in collections

### DIFF
--- a/toyplot/color.py
+++ b/toyplot/color.py
@@ -197,7 +197,7 @@ def broadcast(colors, shape, default=None):
         colors, colormap = colors
 
     # Next, convert the supplied colors into a toyplot color array.
-    if isinstance(colors, collections.Sequence):
+    if isinstance(colors, collections.abc.Sequence):
         colors = numpy.array(colors)
 
     if isinstance(colors, numpy.ndarray):

--- a/toyplot/data.py
+++ b/toyplot/data.py
@@ -138,7 +138,7 @@ class Table(object):
                 keys = [key for key in sorted(data.keys())]
                 values = [data[key] for key in keys]
             # Input data based on sequences.
-            elif isinstance(data, (list, collections.Sequence)):
+            elif isinstance(data, (list, collections.abc.Sequence)):
                 keys = [key for key, value in data]
                 values = [value for key, value in data]
             # Input data based on numpy arrays.


### PR DESCRIPTION
Using toyplot with python 3.10 was causing the following exception:

``` traceback
File "/home/francisco/.local/lib/python3.10/site-packages/toyplot/color.py", line 200, in broadcast
    if isinstance(colors, collections.Sequence):
AttributeError: module 'collections' has no attribute 'Sequence'
```

Investigating the issue led me to realize this was due to a change in the [collections module](https://docs.python.org/3/library/collections.abc.html).
The class `Sequence` was moved from `collections.Sequence` to `collections.abc.Sequence`.
This PR fixes the issue by calling the `Sequence` class from the "new" module.
I did not test it, but according to the documentation, this should be compatible with python 3.3 and up.

Best,

Francisco
