### PR TITLE
fixed deprecated numpy calls

### DIFF
--- a/toyplot/html.py
+++ b/toyplot/html.py
@@ -54,7 +54,7 @@ class _CustomJSONEncoder(json.JSONEncoder):
     # pylint: disable=method-hidden
     def default(self, o): # pragma: no cover
         if isinstance(o, numpy.generic):
-            return numpy.asscalar(o)
+            return o.item()
         if isinstance(o, xml.Element):
             return xml.tostring(o, encoding="unicode", method="html")
         return json.JSONEncoder.default(self, o)

--- a/toyplot/projection.py
+++ b/toyplot/projection.py
@@ -167,7 +167,7 @@ class Piecewise(Projection):
                     raise Exception("Unknown scale: %s" % (scale,)) # pragma: no cover
 
         if range_values.shape == ():
-            range_values = numpy.asscalar(range_values)
+            range_values = range_values.item()
         return range_values
 
     def inverse(self, range_values):
@@ -195,7 +195,7 @@ class Piecewise(Projection):
                     raise Exception("Unknown scale: %s" % (scale,)) # pragma: no cover
 
         if domain_values.shape == ():
-            domain_values = numpy.asscalar(domain_values)
+            domain_values = domain_values.item()
         return domain_values
 
 

--- a/toyplot/reportlab/__init__.py
+++ b/toyplot/reportlab/__init__.py
@@ -124,11 +124,11 @@ def render(svg, canvas):
 
     def set_fill_color(canvas, color):
         canvas.setFillColorRGB(color["r"], color["g"], color["b"])
-        canvas.setFillAlpha(numpy.asscalar(color["a"]))
+        canvas.setFillAlpha(color["a"].item())
 
     def set_stroke_color(canvas, color):
         canvas.setStrokeColorRGB(color["r"], color["g"], color["b"])
-        canvas.setStrokeAlpha(numpy.asscalar(color["a"]))
+        canvas.setStrokeAlpha(color["a"].item())
 
     def render_element(root, element, canvas, styles):
         canvas.saveState()

--- a/toyplot/text.py
+++ b/toyplot/text.py
@@ -41,10 +41,10 @@ def extents(text, angle, style):
 
     for index, theta in enumerate(angle):
         transformation = toyplot.transform.rotation(theta)
-        corner1[index] = corner1[index] * transformation
-        corner2[index] = corner2[index] * transformation
-        corner3[index] = corner3[index] * transformation
-        corner4[index] = corner4[index] * transformation
+        corner1[index] = numpy.diag(corner1[index] * transformation)
+        corner2[index] = numpy.diag(corner2[index] * transformation)
+        corner3[index] = numpy.diag(corner3[index] * transformation)
+        corner4[index] = numpy.diag(corner4[index] * transformation)
 
     left = numpy.minimum(corner1.T[0], numpy.minimum(
         corner2.T[0], numpy.minimum(corner3.T[0], corner4.T[0])))

--- a/toyplot/transform.py
+++ b/toyplot/transform.py
@@ -19,4 +19,5 @@ def rotation(angle):
     theta = numpy.radians(angle)
     cos_theta = numpy.cos(theta)
     sin_theta = numpy.sin(theta)
-    return numpy.matrix([[cos_theta, sin_theta], [-sin_theta, cos_theta]])
+
+    return numpy.array([[cos_theta, sin_theta], [-sin_theta, cos_theta]])


### PR DESCRIPTION
This PR replaces two deprecated numpy calls with their modern, equivalent calls. 

### Problem

toyplot rendering fails with numpy >1.23 because toyplot uses a deprecated `asscalar` call. This call was officially removed from numpy. Numpy 1.23 is the default conda install (at least on x86 macOS), so toyplot is now broken on conda. 

### Changes

#### Change deprecated numpy.asscalar to ndarray.item

Change lines in `reportlab.__init__`, `html.py`, and `projection.py` that look like this:

```
canvas.setStrokeAlpha(numpy.asscalar(color["a"]))
```

To this:

```
canvas.setStrokeAlpha(color["a"].item())
```



#### Change deprecated numpy.matrix to numpy.array call

While fixing this bug, I also fixed a deprecated-but-not-yet-removed call to `numpy.matrix`. In *transform.py*, convert line:

```
return numpy.matrix([[cos_theta, sin_theta], [-sin_theta, cos_theta]])
```

to:

```
return numpy.array([[cos_theta, sin_theta], [-sin_theta, cos_theta]])
```

Which required changing lines in *text.py* that all look like this. 

```
corner1[index] = corner1[index] * transformation
```

to:

```
corner1[index] = numpy.diag(corner1[index] * transformation)
```


### Testing

All regression tests passed (M1 macOS Monterey).