### PR TITLE
use matrix mult on text angle transform arrays

### DIFF
--- a/toyplot/text.py
+++ b/toyplot/text.py
@@ -41,10 +41,10 @@ def extents(text, angle, style):
 
     for index, theta in enumerate(angle):
         transformation = toyplot.transform.rotation(theta)
-        corner1[index] = numpy.diag(corner1[index] * transformation)
-        corner2[index] = numpy.diag(corner2[index] * transformation)
-        corner3[index] = numpy.diag(corner3[index] * transformation)
-        corner4[index] = numpy.diag(corner4[index] * transformation)
+        corner1[index] = numpy.matmul(corner1[index], transformation)
+        corner2[index] = numpy.matmul(corner2[index], transformation)
+        corner3[index] = numpy.matmul(corner3[index], transformation)
+        corner4[index] = numpy.matmul(corner4[index], transformation)
 
     left = numpy.minimum(corner1.T[0], numpy.minimum(
         corner2.T[0], numpy.minimum(corner3.T[0], corner4.T[0])))


### PR DESCRIPTION
Angled text extents seem to be broken in v.1.0.2. I noticed it causing problems in toytree. The problem seems to stem from the recent numpy deprecation updates which replaced a numpy.matrix object with an array in the angle transform function. 

The fix seems easy enough, we just need to explicitly tell numpy to do matrix multiplication with the transform array. 

This example shows the problem in v.1.0.2 where the 90 degree angle example yields incorrect extents very close to 0.
```python
import toyplot
import toyplot.text
print(toyplot.__version__)
print(toyplot.text.extents('hello world', 0, {}))
print(toyplot.text.extents('hello world', 90, {}))
```
```python 
# 1.0.2
# (array([-28.674]), array([28.674]), array([-7.2]), array([7.2]))
# (array([-1.75577612e-15]), array([1.75577612e-15]), array([-4.40872848e-16]), array([4.40872848e-16]))
```
```python 
# 1.0.3-dev
# (array([-28.674]), array([28.674]), array([-7.2]), array([7.2]))
# (array([-7.2]), array([7.2]), array([-28.674]), array([28.674]))
```

