### PR TITLE
Point extents func to fit marker size + stroke

### DIFF
--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -840,8 +840,7 @@ class Point(Mark):
         return toyplot.data.minimax([self._table[column] for column in columns])
 
     def extents(self, axes):
-        """Return extents in 1 or 2 dimensions.
-        """
+        """Return extents in 1 or 2 dimensions."""
         # iterate over entered axes (e.g., ['x', 'y']) if exists for Mark
         assert all(i in self._coordinate_axes for i in axes)
 

--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -839,16 +839,15 @@ class Point(Mark):
         columns = [coordinate_column for coordinate_axis, coordinate_column in zip(itertools.cycle(self._coordinate_axes), self._coordinates) if coordinate_axis == axis]
         return toyplot.data.minimax([self._table[column] for column in columns])
 
-    def extents(self, axis: str):
-        """Return extents in 2 dimensions.
-
-        TODO: could support higher dimensions
+    def extents(self, axes):
+        """Return extents in 1 or 2 dimensions.
         """
         # iterate over entered axes (e.g., ['x', 'y']) if exists for Mark
-        assert all(i in self._coordinate_axes for i in axis)
+        assert all(i in self._coordinate_axes for i in axes)
 
-        # get coordinates
-        coords = tuple(self._table[i] for i in self._coordinates)
+        # get coordinates of 'x' 'y' from potentially ['x', 'y0', 'x', 'y1', ... etc]
+        axis_map = {key: index for index, key in enumerate(self._coordinate_axes)}
+        coords = tuple([self._table[self._coordinates[axis_map[axis]]] for axis in axes])
 
         # get empty extents arrays to be filled below.
         xext = numpy.zeros(coords[0].size)

--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -874,6 +874,8 @@ class Point(Mark):
             # extent is half of size diameter, stroke is already half
             xext[idx] = (width * size) / 2 + stroke_width
             yext[idx] = (height * size) / 2 + stroke_width
+
+        # return is usually parsed: (x, y), (left, right, bottom, top) = ...
         return coords, (-xext, xext, -yext, yext)
 
     @property

--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -855,9 +855,8 @@ class Point(Mark):
         yext = numpy.zeros(coords[0].size)
 
         # extents requires marker shape (rect or not), size, and stroke-width
-        stroke_width = 0
-        if hasattr(self, "_mstyle"):
-            stroke_width = self._mstyle.get("stroke-width", 0)
+        _mstyle = {} if self._mstyle is None else self._mstyle
+        stroke_width = _mstyle.get("stroke-width", 0)
         iterdata = zip(
             range(coords[0].size),
             self._table[self._marker[0]],

--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -855,7 +855,9 @@ class Point(Mark):
         yext = numpy.zeros(coords[0].size)
 
         # extents requires marker shape (rect or not), size, and stroke-width
-        stroke_width = self._mstyle.get("stroke-width", 0)
+        stroke_width = 0
+        if hasattr(self, "_mstyle"):
+            stroke_width = self._mstyle.get("stroke-width", 0)
         iterdata = zip(
             range(coords[0].size),
             self._table[self._marker[0]],


### PR DESCRIPTION
I updated the `.extents()` for Point Marks to return extents of its markers as `msize / 2 + stroke`, unless marker type is "rNxM", where it gets height and width from the marker. I'm not sure if there are other non-symmetric markers that need to be accommodated. I've had something like this implemented in toytree for a while and it seems to work well. Thought it would be good to share. I believe this addresses Issue #164

### BEFORE
![image](https://user-images.githubusercontent.com/25778715/233802319-1dc414eb-e946-4464-a8d2-14ea1c3c1bb8.png)

### AFTER
![image](https://user-images.githubusercontent.com/25778715/233802332-657b44e4-47ec-4240-b657-e074d407b00b.png)

### CONFIRMATION
This shows the new extents seem quite accurate by suppressing the padding and margin:
![image](https://user-images.githubusercontent.com/25778715/233802394-640b92fd-1af5-4fc4-ba63-9c4164a0cebc.png)

