### PR TITLE
Reportlab rename

### DIFF
--- a/backend-report.py
+++ b/backend-report.py
@@ -24,9 +24,9 @@ for module in [
     "toyplot.mp4",
     "toyplot.pdf",
     "toyplot.png",
-    "toyplot.reportlab",
-    "toyplot.reportlab.pdf",
-    "toyplot.reportlab.png",
+    "toyplot.reportlab_",
+    "toyplot.reportlab_.pdf",
+    "toyplot.reportlab_.png",
     "toyplot.svg",
     ]:
     print_report(module)

--- a/toyplot/mark.py
+++ b/toyplot/mark.py
@@ -805,7 +805,7 @@ class Point(Mark):
 
         self._table = toyplot.require.instance(table, toyplot.data.Table)
 
-        # We require at least one coordinate dimension (number of dimensions = D)
+        # We require at last one coordinate dimension (number of dimensions = D)
         self._coordinate_axes = toyplot.require.string_vector(coordinate_axes, min_length=1)
         D = len(self._coordinate_axes)
 
@@ -838,43 +838,6 @@ class Point(Mark):
     def domain(self, axis):
         columns = [coordinate_column for coordinate_axis, coordinate_column in zip(itertools.cycle(self._coordinate_axes), self._coordinates) if coordinate_axis == axis]
         return toyplot.data.minimax([self._table[column] for column in columns])
-
-    def extents(self, axis: str):
-        """Return extents in 2 dimensions.
-
-        TODO: could support higher dimensions
-        """
-        # iterate over entered axes (e.g., ['x', 'y']) if exists for Mark
-        assert all(i in self._coordinate_axes for i in axis)
-
-        # get coordinates
-        coords = tuple(self._table[i] for i in self._coordinates)
-
-        # get empty extents arrays to be filled below.
-        xext = numpy.zeros(coords[0].size)
-        yext = numpy.zeros(coords[0].size)
-
-        # extents requires marker shape (rect or not), size, and stroke-width
-        stroke_width = self._mstyle.get("stroke-width", 0)
-        iterdata = zip(
-            range(coords[0].size),
-            self._table[self._marker[0]],
-            self._table[self._msize[0]],
-        )
-
-        # fill extents (left, right, top, bottom) for each marker
-        for idx, shape, size in iterdata:
-
-            # if 'r2x1' then width is 2X height
-            if shape[0] == "r":
-                width, height = (int(i) for i in shape[1:].split("x"))
-            else:
-                width, height = 1, 1
-
-            # extent is half of size diameter, stroke is already half
-            xext[idx] = (width * size) / 2 + stroke_width
-            yext[idx] = (height * size) / 2 + stroke_width
-        return coords, (-xext, xext, -yext, yext)
 
     @property
     def markers(self):

--- a/toyplot/pdf.py
+++ b/toyplot/pdf.py
@@ -7,7 +7,7 @@
 
 
 import toyplot.require
-import toyplot.reportlab.pdf as implementation
+import toyplot.reportlab_.pdf as implementation
 
 
 def render(canvas, fobj=None, width=None, height=None, scale=None):
@@ -50,7 +50,7 @@ def render(canvas, fobj=None, width=None, height=None, scale=None):
     Notes
     -----
     The output PDF is currently rendered using
-    :func:`toyplot.reportlab.pdf.render()`.
+    :func:`toyplot.reportlab_.pdf.render()`.
     """
     canvas = toyplot.require.instance(canvas, toyplot.canvas.Canvas)
     return implementation.render(canvas, fobj, width, height, scale)

--- a/toyplot/png.py
+++ b/toyplot/png.py
@@ -7,7 +7,7 @@
 
 
 import toyplot.require
-import toyplot.reportlab.png as implementation
+import toyplot.reportlab_.png as implementation
 
 
 def render(canvas, fobj=None, width=None, height=None, scale=None):
@@ -39,7 +39,7 @@ def render(canvas, fobj=None, width=None, height=None, scale=None):
 
     Notes
     -----
-    The output PNG is rendered using :func:`toyplot.reportlab.png.render()`.
+    The output PNG is rendered using :func:`toyplot.reportlab_.png.render()`.
     This is subject to change.
     """
     canvas = toyplot.require.instance(canvas, toyplot.canvas.Canvas)
@@ -73,7 +73,7 @@ def render_frames(canvas, width=None, height=None, scale=None):
     Notes
     -----
     The output PNG images are rendered using
-    :func:`toyplot.reportlab.png.render_frames()`.  This is subject to change.
+    :func:`toyplot.reportlab_.png.render_frames()`.  This is subject to change.
 
     Examples
     --------

--- a/toyplot/reportlab_/__init__.py
+++ b/toyplot/reportlab_/__init__.py
@@ -9,7 +9,6 @@ import base64
 import io
 import re
 
-import numpy
 import reportlab.lib.colors
 import reportlab.lib.utils
 

--- a/toyplot/reportlab_/pdf.py
+++ b/toyplot/reportlab_/pdf.py
@@ -8,7 +8,7 @@
 
 import io
 import reportlab.pdfgen.canvas
-import toyplot.reportlab
+import toyplot.reportlab_
 import toyplot.require
 import toyplot.svg
 
@@ -47,8 +47,7 @@ def render(canvas, fobj=None, width=None, height=None, scale=None):
 
     Examples
     --------
-
-    >>> toyplot.reportlab.pdf.render(canvas, "figure-1.pdf", width=(4, "inches"))
+    >>> toyplot.reportlab_.pdf.render(canvas, "figure-1.pdf", width=(4, "inches"))
     """
     canvas = toyplot.require.instance(canvas, toyplot.canvas.Canvas)
     svg = toyplot.svg.render(canvas)
@@ -63,7 +62,7 @@ def render(canvas, fobj=None, width=None, height=None, scale=None):
     surface.translate(0, scale * canvas.height)
     surface.scale(1, -1)
     surface.scale(scale, scale)
-    toyplot.reportlab.render(svg, surface)
+    toyplot.reportlab_.render(svg, surface)
     surface.showPage()
     surface.save()
     if fobj is None:

--- a/toyplot/reportlab_/png.py
+++ b/toyplot/reportlab_/png.py
@@ -5,14 +5,14 @@
 """Functions to render PNG images using Ghostscript.
 """
 
-
-import distutils.version
+import packaging.version
+# import distutils.version
 import io
 import subprocess
 
 import reportlab.pdfgen.canvas
 
-import toyplot.reportlab
+import toyplot.reportlab_
 import toyplot.require
 import toyplot.svg
 
@@ -29,7 +29,8 @@ for command in ["gs", "gswin64c", "gswin32c"]:
 if _gs_command is None:
     raise Exception("A ghostscript executable is required.")  # pragma: no cover
 
-if distutils.version.StrictVersion(_gs_version) >= "9.14":
+# if distutils.version.StrictVersion(_gs_version) >= "9.14":
+if packaging.version.Version(_gs_version).base_version >= "9.14":
     _gs_resolution = ["-r%s" % (96 * 4), "-dDownScaleFactor=4"]
 else: # pragma: no cover
     _gs_resolution = ["-r%s" % (96)]
@@ -71,7 +72,7 @@ def render(canvas, fobj=None, width=None, height=None, scale=None):
     surface.translate(0, scale * canvas.height)
     surface.scale(1, -1)
     surface.scale(scale, scale)
-    toyplot.reportlab.render(svg, surface)
+    toyplot.reportlab_.render(svg, surface)
     surface.showPage()
     surface.save()
 
@@ -130,7 +131,7 @@ def render_frames(canvas, width=None, height=None, scale=None):
 
     Examples
     --------
-    >>> for frame, png in enumerate(toyplot.reportlab.png.render_frames(canvas)):
+    >>> for frame, png in enumerate(toyplot.reportlab_.png.render_frames(canvas)):
     ...   open("frame-%s.png" % frame, "wb").write(png)
     """
     canvas = toyplot.require.instance(canvas, toyplot.canvas.Canvas)
@@ -145,7 +146,7 @@ def render_frames(canvas, width=None, height=None, scale=None):
         surface.translate(0, scale * canvas.height)
         surface.scale(1, -1)
         surface.scale(scale, scale)
-        toyplot.reportlab.render(svg, surface)
+        toyplot.reportlab_.render(svg, surface)
         surface.showPage()
         surface.save()
 


### PR DESCRIPTION
I understand if you decide not to accept this one, it's a very minor issue.

The issue is that the existence of the `reportlab/` subpackage within toytree creates ambiguity with the library `reportlab` for certain import statements. For example, the following lines in `reportlab/__init__.py` will try to import from the parent folder 'reportlab` instead of from the library. 

```python
import reportlab.lib.colors
import reportlab.lib.utils
```
A simple fix for this is to rename the internal `toyplot/reportlab` folder to `toyplot/reportlab_`, or something similar. I did a simple string replacement to do this for the source code, but did not update the docs.

Here is an example of the import exception that is raised if you try to execute `toyplot/text.py` where it imports from the wrong `reportlab` option:

![image](https://user-images.githubusercontent.com/25778715/233805123-6806dc6b-2494-4175-822f-15dddde3716e.png)

An unrelated issue that this commit also addressed is a deprecation warning raised in toyplot/reportlab/png.py:
```
/home/deren/Documents/toyplot/toyplot/reportlab/png.py:32: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if distutils.version.StrictVersion(_gs_version) >= "9.14":
```

