### PR TITLE
Fix XSS vulnerability in inline scripts (Issue #218)

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -35,6 +35,9 @@ jobs:
       run: |
         coverage run --source toyplot -m behave --tags=~wip --logging-level INFO --no-logcapture
         coverage report
+    - name: Run unit tests
+      run: |
+        ./tests/run_tests.sh
     - name: Upload coverage to Coveralls
       run: coveralls --service=github
       env:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# run_tests.sh
+# Run the Toyplot test suite.
+# Requires: Python with unittest module (standard library)
+
+echo "Running Toyplot test suite..."
+
+# Change to the project root directory
+cd "$(dirname "$0")/.."
+
+# Run tests using unittest discovery
+python -m unittest discover -s tests -p "test_*.py" -v
+
+echo "All tests passed."

--- a/tests/test_html_security.py
+++ b/tests/test_html_security.py
@@ -1,0 +1,37 @@
+import unittest
+import xml.etree.ElementTree as xml
+
+import toyplot
+import toyplot.html
+import toyplot.data
+from toyplot.html import RenderContext, _render_javascript  # accessing internal for targeted test
+
+
+class TestHTMLSecurity(unittest.TestCase):
+
+    def test_script_closing_tag_escaped(self):
+        # Create a minimal render context
+        root = xml.Element("div")
+        context = RenderContext(scenegraph=None, root=root)
+        # Simulate a module definition (not strictly necessary, but realistic)
+        context.define("toyplot/test/module", value={"k": 1})
+        # Inject a javascript call with an argument containing the sentinel sequence
+        malicious = "safe prefix </script><script>alert('xss')</script> suffix"
+        context.require(
+            dependencies=["toyplot/test/module"],
+            arguments=[malicious],
+            code="""function(mod, arg){ if(!mod.k){ throw new Error('module fail'); } }""",
+        )
+        # Assign a parent for script injection destination
+        context = context.copy(parent=root)
+        _render_javascript(context)
+
+        # Extract script content
+        scripts = [child.text for child in root.findall("script")]
+        self.assertTrue(scripts, "No <script> element generated.")
+        combined = "\n".join(scripts)
+
+        # Raw closing sequence must not appear
+        self.assertNotIn("</script>", combined, "Unescaped </script> found in script block!")
+        # Escaped form should appear
+        self.assertIn("<\\/script>", combined, "Escaped </script> not present.")

--- a/toyplot/html.py
+++ b/toyplot/html.py
@@ -1041,10 +1041,7 @@ def _render_javascript(context):
                 search(requirement, visited, modules)
 
     # Generate the code.
-    script = """(function()
-{
-var modules={};
-"""
+    script = """(function()\n{\nvar modules={};\n"""
 
     # Initialize required modules.
     for name, (requirements, factory, value) in modules:
@@ -1072,6 +1069,22 @@ var modules={};
         script += """);\n"""
 
     script += """})();"""
+
+    # Security Hardening (Issue #218):
+    # Inline <script> blocks terminate when the HTML parser encounters the literal
+    # sequence </script>, even if it occurs inside a JavaScript string literal.
+    # User-controlled data funneled through json.dumps() could therefore inject
+    # arbitrary script by embedding </script><script>evil()</script>.
+    #
+    # Mitigation: escape every occurrence of </script> inside the script payload
+    # before inserting it into the DOM. The conventional safe form is <\/script>,
+    # which the JavaScript engine interprets the same, while the HTML parser does
+    # not treat it as an end tag.
+    #
+    # Note: We intentionally perform a plain string replacement across the entire
+    # script text. This is safe because it only increases escaping and does not
+    # alter runtime semantics. Future refactors may move to a data + loader model.
+    script = script.replace("</script>", "<\\/script>")
 
     # Create the DOM elements.
     xml.SubElement(context.parent, "script").text = script


### PR DESCRIPTION
## Summary
- escape literal </script> sequences in generated inline JavaScript to block injection
- add a unittest-based test suite with coverage for the escaping behavior
- hook the new tests into CI via the existing GitHub Actions workflow

## Testing
- ./tests/run_tests.sh